### PR TITLE
refactor: throw error instead of null in server

### DIFF
--- a/wealth-sync/src/server/auth/config.ts
+++ b/wealth-sync/src/server/auth/config.ts
@@ -1,7 +1,7 @@
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { type DefaultSession, type NextAuthConfig } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import DiscordProvider from "next-auth/providers/discord";
+// import DiscordProvider from "next-auth/providers/discord";
 import Facebook from "next-auth/providers/facebook";
 import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
@@ -80,7 +80,7 @@ export const authConfig = {
         };
       },
     }),
-    DiscordProvider,
+    // DiscordProvider,
     Facebook({
       clientId: process.env.FACEBOOK_CLIENT_ID,
       clientSecret: process.env.FACEBOOK_CLIENT_SECRET,

--- a/wealth-sync/src/server/auth/validateUser.ts
+++ b/wealth-sync/src/server/auth/validateUser.ts
@@ -6,11 +6,14 @@ export async function validateUser(email: string, password: string) {
     where: { email },
   });
 
-  if (!user?.password) return null;
+  if (!user?.password) throw new Error('User does not have a password!');
 
-  const isPasswordValid = await bcrypt.compare(password, user.password);
-
-  if (!isPasswordValid) return null;
+  try {
+    const isPasswordValid = await bcrypt.compare(password, user.password);
+    if (!isPasswordValid) throw new Error('Password is invalid!');
+  } catch (error) {
+    throw new Error(error as string);
+  }
 
   return user;
 }

--- a/wealth-sync/src/server/auth/validateUser.ts
+++ b/wealth-sync/src/server/auth/validateUser.ts
@@ -1,19 +1,22 @@
 import bcrypt from "bcryptjs";
 import { db } from "../db";
+export class InvalidCredentialsError extends Error {
+  constructor() {
+    super("Invalid credentials");
+    this.name = "InvalidCredentialsError";
+  }
+}
 
 export async function validateUser(email: string, password: string) {
   const user = await db.user.findUnique({
     where: { email },
   });
-
-  if (!user?.password) throw new Error('User does not have a password!');
-
+  if (!user?.password) throw new InvalidCredentialsError();
   try {
     const isPasswordValid = await bcrypt.compare(password, user.password);
-    if (!isPasswordValid) throw new Error('Password is invalid!');
+    if (!isPasswordValid) throw new InvalidCredentialsError();
   } catch (error) {
-    throw new Error(error as string);
+    throw error;
   }
-
   return user;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now gives explicit error feedback for missing or incorrect passwords, improving login diagnostics and resolution.

* **Changes**
  * Discord sign-in option has been removed; available sign-in methods are Credentials, Facebook, GitHub, and Google.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->