### PR TITLE
featL Add recent news on initial load of news page

### DIFF
--- a/wealth-sync/src/app/api/news/route.ts
+++ b/wealth-sync/src/app/api/news/route.ts
@@ -13,11 +13,35 @@ export async function GET(request: Request) {
   }
 
   if (!query) {
-    return NextResponse.json({ error: "Query is required" }, { status: 400 });
+    const newsRes = await fetch(
+      `${FINNHUB_BASE_URL}/news?category=general&token=${API_KEY}`,
+    );
+    if (!newsRes.ok)
+      throw new Error(`News fetch failed: ${newsRes.statusText}`);
+    const newsData = (await newsRes.json()) as Array<{
+      headline: string;
+      datetime: number;
+      source: string;
+      url: string;
+      image?: string;
+    }>;
+    return NextResponse.json({
+      symbol: null,
+      name: "Market News",
+      description: "Latest market & financial headlines",
+      news: Array.isArray(newsData)
+        ? newsData.slice(0, 30).map((item) => ({
+            headline: item.headline,
+            datetime: item.datetime,
+            source: item.source,
+            datetimer: new Date(item.datetime * 1000).toISOString(),
+            url: item.url,
+            image: item.image,
+          }))
+        : [],
+    });
   }
-
   try {
-    // Search for the symbol
     const searchResponse = await fetch(
       `${FINNHUB_BASE_URL}/search?q=${encodeURIComponent(query)}&token=${API_KEY}`,
     );
@@ -84,7 +108,6 @@ export async function GET(request: Request) {
         }>
       >,
     ]);
-
 
     return NextResponse.json({
       symbol,

--- a/wealth-sync/src/components/NewsPageComponents/ErrorComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/ErrorComponent.tsx
@@ -4,7 +4,13 @@ import { IoIosWarning } from "react-icons/io";
 import { Button } from "../ui/button";
 import { useTranslations } from "next-intl";
 
-function ErrorComponent({ error }: { error: string }) {
+function ErrorComponent({
+  error,
+  fetchRecentNews,
+}: {
+  error: string;
+  fetchRecentNews: (event: React.SyntheticEvent<EventTarget>) => void;
+}) {
   const t = useTranslations("NewsPage.ErrorComponent");
 
   return (
@@ -15,7 +21,12 @@ function ErrorComponent({ error }: { error: string }) {
     >
       <IoIosWarning className="text-destructive mx-auto mt-6 text-6xl" />
       <p className="text-destructive text-md pt-2 text-center">{error}</p>
-      <Button size={"default"} variant={"outline"} className="mt-5 p-5">
+      <Button
+        size={"default"}
+        variant={"outline"}
+        className="mt-5 p-5"
+        onClick={fetchRecentNews}
+      >
         {t("seeRecentNewsButton")}
       </Button>
     </div>

--- a/wealth-sync/src/components/NewsPageComponents/ErrorComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/ErrorComponent.tsx
@@ -1,14 +1,23 @@
+"use client";
+
 import { IoIosWarning } from "react-icons/io";
+import { Button } from "../ui/button";
+import { useTranslations } from "next-intl";
 
 function ErrorComponent({ error }: { error: string }) {
+  const t = useTranslations("NewsPage.ErrorComponent");
+
   return (
     <div
       role="alert"
       aria-live="assertive"
-      className="mt-10 rounded-3xl border border-gray-200 bg-white/80 p-6 shadow-sm dark:border-gray-700 dark:bg-slate-900/80"
+      className="mt-10 flex flex-col rounded-3xl border border-gray-200 bg-white/80 p-6 shadow-sm dark:border-gray-700 dark:bg-slate-900/80"
     >
       <IoIosWarning className="text-destructive mx-auto mt-6 text-6xl" />
       <p className="text-destructive text-md pt-2 text-center">{error}</p>
+      <Button size={"default"} variant={"outline"} className="mt-5 p-5">
+        {t("seeRecentNewsButton")}
+      </Button>
     </div>
   );
 }

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -5,13 +5,10 @@ import NewsResults from "./NewsResults";
 import NoNewsResult from "./NoNewsResult";
 import type { TickerInfoType } from "./types";
 import TickerInfoComponent from "./TickerInfoComponent";
-import { useTranslations } from "next-intl";
 import LoadingCard from "../Common/LoadingCard";
 import TickerSearchForm from "./TickerSearchForm";
 
 export default function NewsPage() {
-  const t = useTranslations("NewsPage");
-
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -19,7 +19,7 @@ export default function NewsPage() {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<TickerInfoType | null>(null);
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function handleTickerSearch(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const trimmedQuery = query.trim();
@@ -46,11 +46,12 @@ export default function NewsPage() {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
       setLoading(false);
+      setQuery("");
     }
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-10 mt-13">
+    <div className="mx-auto mt-13 max-w-4xl px-4 py-10">
       <div className="mb-8 rounded-3xl border border-gray-200 bg-white/80 p-8 shadow-sm dark:border-gray-700 dark:bg-slate-900/80">
         <h1 className="text-3xl font-semibold">{t("title")}</h1>
         <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
@@ -58,7 +59,7 @@ export default function NewsPage() {
         </p>
 
         <form
-          onSubmit={handleSubmit}
+          onSubmit={handleTickerSearch}
           className="mt-6 flex flex-col gap-4 sm:flex-row"
         >
           <Input

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -25,7 +25,12 @@ export default function NewsPage() {
     setLoading(true);
     try {
       const response = await fetch("/api/news");
-      const data = (await response.json()) as TickerInfoType;
+      const data = (await response.json()) as TickerInfoType & {
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(data.error ?? "Failed to load asset data");
+      }
       setResult(data);
     } catch (err) {
       console.error("Failed to fetch recent news:", err);

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import NewsResults from "./NewsResults";
 import NoNewsResult from "./NoNewsResult";
 import type { TickerInfoType } from "./types";
 import TickerInfoComponent from "./TickerInfoComponent";
 import { useTranslations } from "next-intl";
 import LoadingCard from "../Common/LoadingCard";
-import ErrorComponent from "./ErrorComponent";
+import TickerSearchForm from "./TickerSearchForm";
 
 export default function NewsPage() {
   const t = useTranslations("NewsPage");
@@ -52,29 +50,13 @@ export default function NewsPage() {
 
   return (
     <div className="mx-auto mt-13 max-w-4xl px-4 py-10">
-      <div className="mb-8 rounded-3xl border border-gray-200 bg-white/80 p-8 shadow-sm dark:border-gray-700 dark:bg-slate-900/80">
-        <h1 className="text-3xl font-semibold">{t("title")}</h1>
-        <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-          {t("description")}
-        </p>
-
-        <form
-          onSubmit={handleTickerSearch}
-          className="mt-6 flex flex-col gap-4 sm:flex-row"
-        >
-          <Input
-            placeholder={t("searchPlaceholder")}
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-          />
-          <Button type="submit" disabled={loading}>
-            {loading ? t("searching") : t("search")}
-          </Button>
-        </form>
-
-        {error && <ErrorComponent error={error} />}
-      </div>
-
+      <TickerSearchForm
+        query={query}
+        setQuery={setQuery}
+        loading={loading}
+        handleTickerSearch={handleTickerSearch}
+        error={error}
+      />
       {loading && <LoadingCard />}
       {result && (
         <div className="space-y-6">

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -7,6 +7,7 @@ import type { TickerInfoType } from "./types";
 import TickerInfoComponent from "./TickerInfoComponent";
 import LoadingCard from "../Common/LoadingCard";
 import TickerSearchForm from "./TickerSearchForm";
+import { toast } from "sonner";
 
 export default function NewsPage() {
   const [query, setQuery] = useState("");
@@ -19,16 +20,22 @@ export default function NewsPage() {
   }, []);
 
   async function fetchRecentNews() {
+    setQuery("");
+    setError(null);
+    setLoading(true);
     try {
       const response = await fetch("/api/news");
-      const data = await response.json();
+      const data = (await response.json()) as TickerInfoType;
       setResult(data);
     } catch (err) {
       console.error("Failed to fetch recent news:", err);
+      toast.error("Failed to load news!");
       setError(
         "Failed to load recent news" +
           (err instanceof Error ? `: ${err.message}` : ""),
       );
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -68,6 +75,7 @@ export default function NewsPage() {
         loading={loading}
         handleTickerSearch={handleTickerSearch}
         error={error}
+        fetchRecentNews={fetchRecentNews}
       />
       {loading && <LoadingCard />}
       {result && (

--- a/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/NewsPageComponent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import NewsResults from "./NewsResults";
 import NoNewsResult from "./NoNewsResult";
 import type { TickerInfoType } from "./types";
@@ -14,6 +14,24 @@ export default function NewsPage() {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<TickerInfoType | null>(null);
 
+  useEffect(() => {
+    void fetchRecentNews();
+  }, []);
+
+  async function fetchRecentNews() {
+    try {
+      const response = await fetch("/api/news");
+      const data = await response.json();
+      setResult(data);
+    } catch (err) {
+      console.error("Failed to fetch recent news:", err);
+      setError(
+        "Failed to load recent news" +
+          (err instanceof Error ? `: ${err.message}` : ""),
+      );
+    }
+  }
+
   async function handleTickerSearch(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -23,7 +41,6 @@ export default function NewsPage() {
     setLoading(true);
     setError(null);
     setResult(null);
-
     try {
       const response = await fetch(
         `/api/news?query=${encodeURIComponent(trimmedQuery)}`,
@@ -31,11 +48,9 @@ export default function NewsPage() {
       const data = (await response.json()) as TickerInfoType & {
         error?: string;
       };
-
       if (!response.ok) {
         throw new Error(data.error ?? "Failed to load asset data");
       }
-
       setResult(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");

--- a/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
@@ -11,6 +11,7 @@ type TickerSearchFormProps = {
   loading: boolean;
   handleTickerSearch: (event: React.FormEvent<HTMLFormElement>) => void;
   error: string | null;
+  fetchRecentNews: (event: React.SyntheticEvent<EventTarget>) => void;
 };
 
 export default function TickerSearchForm({
@@ -19,6 +20,7 @@ export default function TickerSearchForm({
   loading,
   handleTickerSearch,
   error,
+  fetchRecentNews,
 }: TickerSearchFormProps) {
   const t = useTranslations("NewsPage");
 
@@ -43,7 +45,9 @@ export default function TickerSearchForm({
         </Button>
       </form>
 
-      {error && <ErrorComponent error={error} />}
+      {error && (
+        <ErrorComponent error={error} fetchRecentNews={fetchRecentNews} />
+      )}
     </div>
   );
 }

--- a/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
@@ -1,4 +1,4 @@
-'use client";';
+'use client';
 
 import { useTranslations } from "next-intl";
 import { Input } from "@/components/ui/input";

--- a/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
+++ b/wealth-sync/src/components/NewsPageComponents/TickerSearchForm.tsx
@@ -1,0 +1,49 @@
+'use client";';
+
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import ErrorComponent from "./ErrorComponent";
+
+type TickerSearchFormProps = {
+  query: string;
+  setQuery: (query: string) => void;
+  loading: boolean;
+  handleTickerSearch: (event: React.FormEvent<HTMLFormElement>) => void;
+  error: string | null;
+};
+
+export default function TickerSearchForm({
+  query,
+  setQuery,
+  loading,
+  handleTickerSearch,
+  error,
+}: TickerSearchFormProps) {
+  const t = useTranslations("NewsPage");
+
+  return (
+    <div className="mb-8 rounded-3xl border border-gray-200 bg-white/80 p-8 shadow-sm dark:border-gray-700 dark:bg-slate-900/80">
+      <h1 className="text-3xl font-semibold">{t("title")}</h1>
+      <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
+        {t("description")}
+      </p>
+
+      <form
+        onSubmit={handleTickerSearch}
+        className="mt-6 flex flex-col gap-4 sm:flex-row"
+      >
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Button type="submit" disabled={loading}>
+          {loading ? t("searching") : t("search")}
+        </Button>
+      </form>
+
+      {error && <ErrorComponent error={error} />}
+    </div>
+  );
+}

--- a/wealth-sync/src/components/NewsPageComponents/types.ts
+++ b/wealth-sync/src/components/NewsPageComponents/types.ts
@@ -1,12 +1,17 @@
 export type TickerInfoType = {
-  symbol: string;
+  symbol?: string | null;
   name: string;
-  price: string;
-  ipo?: string;
-  logo: string;
-  marketCapitalization: string;
+  price?: string | null;
+  ipo?: string | null;
+  logo?: string | null;
+  marketCapitalization?: string | null;
   description?: string;
-  news: Array<{ headline: string; source: string; url: string; datetime: number }>;
+  news: Array<{
+    headline: string;
+    source: string;
+    url: string;
+    datetime: number;
+  }>;
   quote?: {
     c?: number; // Current price
     d?: number; // Change

--- a/wealth-sync/src/messages/bg.json
+++ b/wealth-sync/src/messages/bg.json
@@ -690,6 +690,9 @@
     },
     "NewsResults": {
       "latestNews": "Последни новини"
+    },
+    "ErrorComponent": {
+      "seeRecentNewsButton": "Обратно към новините"
     }
   },
   "DashboardWelcomeHeader": {

--- a/wealth-sync/src/messages/en.json
+++ b/wealth-sync/src/messages/en.json
@@ -689,6 +689,9 @@
     },
     "NewsResults": {
       "latestNews": "Latest News"
+    },
+    "ErrorComponent": {
+      "seeRecentNewsButton": "See recent news"
     }
   },
   "DashboardWelcomeHeader": {


### PR DESCRIPTION
###  Add recent news on load of news page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News page now automatically loads recent market news upon page load
  * Users can view general market news without entering a search query
  
* **Improvements**
  * Enhanced error handling with a recovery button to return to recent news
  * Improved internationalization support across error messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoyanK95/wealth-sync/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->